### PR TITLE
feat: add apps role with Spotify installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,17 @@ ansible-playbook playbook.yml --ask-vault-pass --skip-tags fonts,system
 |------|---------|
 | `base` | Core apt packages: zsh, tmux, ripgrep, fd-find, fzf, eza, git-delta, jq, gh |
 | `tools` | CLI tools: uv, nvm+node, rustup, zoxide, starship, direnv, atuin, neovim, lazygit, claude |
+| `apps` | Spotify |
 | `fonts` | Hack Nerd Font |
 | `symlinks` | Links dotfiles and scripts |
 | `system` | GNOME keyboard: Caps to Escape, fast key repeat rate |
 | `git` | Personal multi-account GitHub setup |
+
+The `apps` role currently only supports Debian-based systems. Skip it on other distros:
+
+```sh
+ansible-playbook playbook.yml --skip-tags apps
+```
 
 ---
 

--- a/playbook.yml
+++ b/playbook.yml
@@ -9,6 +9,7 @@
         - test
         - base
         - tools
+        - apps
         - fonts
         - symlinks
         - system
@@ -20,6 +21,9 @@
 
     - role: tools
       tags: tools
+
+    - role: apps
+      tags: apps
 
     - role: fonts
       tags: fonts

--- a/roles/apps/tasks/install_spotify.yml
+++ b/roles/apps/tasks/install_spotify.yml
@@ -1,0 +1,25 @@
+---
+- name: Download Spotify GPG key
+  ansible.builtin.get_url:
+    url: https://download.spotify.com/debian/pubkey_5384CE82BA52C83A.asc
+    dest: /usr/share/keyrings/spotify.asc
+    mode: "0644"
+  become: true
+
+- name: Convert Spotify GPG key to binary format
+  ansible.builtin.command:
+    cmd: gpg --yes --dearmor -o /usr/share/keyrings/spotify.gpg /usr/share/keyrings/spotify.asc
+    creates: /usr/share/keyrings/spotify.gpg
+  become: true
+
+- name: Add Spotify APT repository
+  ansible.builtin.apt_repository:
+    repo: "deb [signed-by=/usr/share/keyrings/spotify.gpg] https://repository.spotify.com stable non-free"
+    filename: spotify
+  become: true
+
+- name: Install Spotify
+  ansible.builtin.apt:
+    name: spotify-client
+    update_cache: true
+  become: true

--- a/roles/apps/tasks/main.yml
+++ b/roles/apps/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Install Spotify
+  ansible.builtin.include_tasks: install_spotify.yml
+  when: ansible_facts['os_family'] == "Debian"


### PR DESCRIPTION
## Summary

- Adds a new `apps` Ansible role for GUI desktop applications
- Installs Spotify via GPG key + APT repository (Debian-based only), following the same pattern as the existing WezTerm installation
- Updates `playbook.yml` to include the new role with an `apps` tag
- Updates README with the new role in the roles table and a note that it is Debian-only

## Test plan

- [ ] Dry-run: `ansible-playbook playbook.yml --tags apps --check`
- [ ] Full run: `ansible-playbook playbook.yml --tags apps`
- [ ] Confirm Spotify launches
- [ ] Re-run to verify idempotency (no changes reported)
- [ ] On non-Debian: confirm `--skip-tags apps` works cleanly