### PR TITLE
feat: add docker installation to tools role

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Debian-based Linux and WSL.
    chsh -s $(which zsh)
    ```
 
+   This also applies the docker group membership set by the `tools` role — verify with
+   `docker run hello-world`.
+
 5. Fix the git remote to use SSH (only if you're me):
 
    ```sh
@@ -112,7 +115,7 @@ ansible-playbook playbook.yml --ask-vault-pass --skip-tags fonts,system
 | Role | Purpose |
 |------|---------|
 | `base` | Core apt packages: zsh, tmux, ripgrep, fd-find, fzf, eza, git-delta, jq, gh |
-| `tools` | CLI tools: uv, nvm+node, rustup, zoxide, starship, direnv, atuin, neovim, lazygit, claude |
+| `tools` | CLI tools: uv, nvm+node, rustup, zoxide, starship, direnv, atuin, neovim, lazygit, claude, docker |
 | `apps` | Spotify |
 | `fonts` | Hack Nerd Font |
 | `symlinks` | Links dotfiles and scripts |

--- a/roles/tools/tasks/install_docker.yml
+++ b/roles/tools/tasks/install_docker.yml
@@ -1,0 +1,78 @@
+---
+- name: Remove conflicting Docker packages
+  ansible.builtin.apt:
+    name:
+      - docker.io
+      - docker-compose
+      - docker-compose-v2
+      - docker-doc
+      - podman-docker
+      - containerd
+      - runc
+    state: absent
+  become: true
+
+- name: Install Docker prerequisites
+  ansible.builtin.apt:
+    name:
+      - ca-certificates
+      - curl
+    state: present
+    update_cache: true
+  become: true
+
+- name: Create /etc/apt/keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+  become: true
+
+- name: Download Docker GPG key
+  ansible.builtin.get_url:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    dest: /etc/apt/keyrings/docker.asc
+    mode: "0644"
+  become: true
+
+- name: Get dpkg architecture
+  ansible.builtin.command: dpkg --print-architecture
+  register: dpkg_arch
+  changed_when: false
+
+- name: Add Docker APT repository
+  ansible.builtin.copy:
+    dest: /etc/apt/sources.list.d/docker.sources
+    content: |
+      Types: deb
+      URIs: https://download.docker.com/linux/ubuntu
+      Suites: {{ ansible_facts['distribution_release'] }}
+      Components: stable
+      Architectures: {{ dpkg_arch.stdout }}
+      Signed-By: /etc/apt/keyrings/docker.asc
+    mode: "0644"
+  become: true
+
+- name: Install Docker CE and plugins
+  ansible.builtin.apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-buildx-plugin
+      - docker-compose-plugin
+    update_cache: true
+  become: true
+
+- name: Create docker group
+  ansible.builtin.group:
+    name: docker
+    state: present
+  become: true
+
+- name: Add user to docker group
+  ansible.builtin.user:
+    name: "{{ lookup('env', 'USER') }}"
+    groups: docker
+    append: true
+  become: true

--- a/roles/tools/tasks/main.yml
+++ b/roles/tools/tasks/main.yml
@@ -55,6 +55,9 @@
 - name: Install github-mcp-server
   include_tasks: install_github_mcp_server.yml
 
+- name: Install docker
+  include_tasks: install_docker.yml
+
 - name: Clean up installer directory
   ansible.builtin.file:
     path: "{{ user_home }}/.tmp"


### PR DESCRIPTION
## Summary

- Adds `install_docker.yml` to the `tools` role, following the official Docker Ubuntu install flow
- Removes legacy conflicting packages, adds GPG key to `/etc/apt/keyrings/`, writes a deb822 `.sources` file, installs `docker-ce`, `docker-ce-cli`, `containerd.io`, `docker-buildx-plugin`, and `docker-compose-plugin`
- Creates the `docker` group and adds the current user (no-sudo usage after re-login)
- Updates README: adds docker to the tools role description, notes that the post-install logout also activates group membership

## Test plan

- [ ] Run `ansible-playbook playbook.yml --tags tools` on a clean Ubuntu install
- [ ] `docker --version` returns a version string
- [ ] `docker compose version` returns a version string
- [ ] Log out and back in, then `groups` includes `docker`
- [ ] `docker run hello-world` succeeds without sudo